### PR TITLE
Move WIP docs to their own location

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,9 +10,6 @@
 ## Thread Architecture
 
 * [Thread safety in the JVM](thread-architecture/thread-safety.md)
-* [WIP Server ticks](thread-architecture/wip-tick-threads.md)
-* [WIP Acquirable API](thread-architecture/wip-acquirable-api/README.md)
-  * [The inside](thread-architecture/wip-acquirable-api/inside-the-api.md)
 
 ## World
 
@@ -25,7 +22,6 @@
 
 ## Feature
 
-* [WIP Adventure](feature/adventure.md)
 * [Player capabilities](feature/player-capabilities.md)
 * [Events](feature/events.md)
 * [Entities](feature/entities/README.md)
@@ -46,4 +42,11 @@
 
 * [Data](storage/data.md)
 * [Persistent data](storage/persistent-data.md)
+
+## Release Candidates
+
+* [Adventure](candidates/adventure.md)
+* [WIP Server ticks](candidates/tick-threads.md)
+* [WIP Acquirable API](candidates/acquirable-api/README.md)
+  * [The inside](candidates/acquirable-api/inside-the-api.md)
 

--- a/candidates/acquirable-api/README.md
+++ b/candidates/acquirable-api/README.md
@@ -1,8 +1,9 @@
-# WIP Acquirable API
-
 {% hint style="info" %}
-This page is WIP, the Acquirable API is not out yet. It is however a way for us to harvest feedbacks for future improvement/rework
+This API is currently not in mainstream Minestom. 
+The working version can be found [here](https://github.com/Minestom/Minestom/tree/thread-safety-experimental).
 {% endhint %}
+
+# Acquirable API
 
 ## Presentation
 
@@ -132,7 +133,7 @@ Collection<Player> players = connectionManager.getUnsafeOnlinePlayers();
 ```
 
 {% hint style="warning" %}
-Those are not safe operations, be sure to read the [Thread safety](../thread-safety.md) page to understand the implications.
+Those are not safe operations, be sure to read the [Thread safety](../../thread-architecture/thread-safety.md) page to understand the implications.
 {% endhint %}
 
 I would personally recommend commenting everywhere you use those unsafe methods to indicate why this operation does not compromise the application thread-safety. If you cannot find any reason, you likely shouldn't.

--- a/candidates/acquirable-api/inside-the-api.md
+++ b/candidates/acquirable-api/inside-the-api.md
@@ -4,13 +4,18 @@ description: >-
   safely
 ---
 
+{% hint style="info" %}
+This API is currently not in mainstream Minestom.
+The working version can be found [here](https://github.com/Minestom/Minestom/tree/thread-safety-experimental).
+{% endhint %}
+
 # The inside
 
 I will begin by saying that you do not need to know anything written here to utilize the acquirable API. It can however teach you about our code structure and how it achieves thread-safety. Be sure to read all the previous pages in order to properly understand everything said here.
 
 ## Tick architecture 
 
-As described in [Server ticks](../wip-tick-threads.md), ticks are separated in multiple batches. After those are created, every batch gets assigned to a thread from the ThreadProvider thread pool.
+As described in [Server ticks](../tick-threads.md), ticks are separated in multiple batches. After those are created, every batch gets assigned to a thread from the ThreadProvider thread pool.
 
 How are batches assigned? Well, each batch has a "cost" based on the number of entities/chunks/instances it contains. This is less efficient compared to the famous `ExecutorService` interface in the JDK, but it has a huge advantage in our case for acquisitions.
 

--- a/candidates/adventure.md
+++ b/candidates/adventure.md
@@ -1,4 +1,9 @@
-# WIP Adventure
+{% hint style="info" %}
+This API is currently not in mainstream Minestom.
+The working version can be found [here](https://github.com/kezz/Minestom/tree/adventure).
+{% endhint %}
+
+# Adventure
 
 Adventure is a library for server-controllable user interface elements in Minecraft. For a guide on how to use Adventure, check out the [Adventure documentation](https://docs.adventure.kyori.net/).
 

--- a/candidates/tick-threads.md
+++ b/candidates/tick-threads.md
@@ -1,4 +1,9 @@
-# WIP Server ticks
+{% hint style="info" %}
+This API is currently not in mainstream Minestom.
+The working version can be found [here](https://github.com/Minestom/Minestom/tree/thread-safety-experimental).
+{% endhint %}
+
+# Server ticks
 
 In Minestom, you have the choice to organize how you want threads to execute your instances, chunks & entities tick. This is possible by creating your own `ThreadProvider` \(or use an already existing one\).
 


### PR DESCRIPTION
The mix of WIP and present docs felt somewhat confusing, so now there is a section at the bottom for all of the WIP apis, with links to their branches.