### PR TITLE
Add version to extension.json example

### DIFF
--- a/expansion/extensions.md
+++ b/expansion/extensions.md
@@ -39,6 +39,7 @@ Then, create a `extension.json` at the root of the resources folder \(`src/main/
 {
   "entrypoint": "testextension.TestExtension",
   "name": "TestExtension",
+  "version": "1.0.0",
   "codeModifiers": [
     "testextension.TestModifier"
   ],


### PR DESCRIPTION
Minestom gives a warning if a version is not provided but there is no version variable in the example `extension.json`

(DiscoveredExtension.verifyIntegrity) - WARN - Extension 'TestExtension' did not specify a version.
(DiscoveredExtension.verifyIntegrity) - WARN - Extension 'TestExtension' will continue to load but should specify a plugin version.